### PR TITLE
Bold on Click

### DIFF
--- a/public/chordDiagram.js
+++ b/public/chordDiagram.js
@@ -148,6 +148,18 @@ define(function(require) {
               return matrix.names[d.index];
             })
             .style("cursor", "default")
+            .style("font-weight", function(d){
+              if(selectedRibbon &&
+                (
+                  (selectedRibbon.sourceIndex === d.index) ||
+                  (selectedRibbon.targetIndex === d.index)
+                )
+              ){
+                return "bold";
+              } else {
+                return "normal";
+              }
+            })
             .call(chordGroupHover);
 
         // Render the chord group arcs.

--- a/public/chordDiagram.js
+++ b/public/chordDiagram.js
@@ -14,10 +14,16 @@ define(function(require) {
         outerPadding = 50,
         arcThickness = 20,
         padAngle = 0.07,
+        labelPadding = 10,
+
+        // Opacity values common to ribbons and arcs
+        // depending on whether or not they are selected.
+        defaultOpacity = 0.6,
+        fadedOpacity = 0.1,
+
         outerRadius = width / 2 - outerPadding,
         innerRadius = outerRadius - arcThickness,
-        labelPadding = 10,
-        defaultOpacity = 0.6,
+
         selectedRibbon = null,
         hoveredChordGroup = null,
         data = null,
@@ -137,20 +143,19 @@ define(function(require) {
 
         // Compute locals.
         chordGroups
-          .select("text")
-            .each(function(group) {
+          .each(function(group) {
 
-              angle.set(this, (group.startAngle + group.endAngle) / 2);
+            angle.set(this, (group.startAngle + group.endAngle) / 2);
 
-              flip.set(this, angle.get(this) > Math.PI);
+            flip.set(this, angle.get(this) > Math.PI);
 
-              selected.set(this, selectedRibbon &&
-                (
-                  (selectedRibbon.sourceIndex === group.index) ||
-                  (selectedRibbon.targetIndex === group.index)
-                )
-              );
-            })
+            selected.set(this, selectedRibbon &&
+              (
+                (selectedRibbon.sourceIndex === group.index) ||
+                (selectedRibbon.targetIndex === group.index)
+              )
+            );
+          })
 
         // Add labels
         chordGroups
@@ -171,7 +176,7 @@ define(function(require) {
             })
             .style("cursor", "default")
             .style("font-weight", function(group){
-              return selected.get(this) ? "bold" : "normal";
+              return selected.get(this.parentNode) ? "bold" : "normal";
             })
             .call(chordGroupHover);
 
@@ -181,6 +186,9 @@ define(function(require) {
             .attr("d", arc)
             .style("fill", function(group) {
               return color(matrix.names[group.index]);
+            })
+            .style("opacity", function(group){
+              return selected.get(this.parentNode) ? defaultOpacity : fadedOpacity;
             })
             .call(chordGroupHover);
 
@@ -217,7 +225,7 @@ define(function(require) {
                 } else {
 
                   // and show all others faded out.
-                  return 0.1;
+                  return fadedOpacity;
                 }
               } else {
 
@@ -234,7 +242,7 @@ define(function(require) {
                   } else {
 
                     // and show all others faded out.
-                    return 0.1;
+                    return fadedOpacity;
                   }
                 } else {
 

--- a/public/chordDiagram.js
+++ b/public/chordDiagram.js
@@ -139,8 +139,17 @@ define(function(require) {
         chordGroups
           .select("text")
             .each(function(group) {
+
               angle.set(this, (group.startAngle + group.endAngle) / 2);
+
               flip.set(this, angle.get(this) > Math.PI);
+
+              selected.set(this, selectedRibbon &&
+                (
+                  (selectedRibbon.sourceIndex === group.index) ||
+                  (selectedRibbon.targetIndex === group.index)
+                )
+              );
             })
 
         // Add labels
@@ -162,16 +171,7 @@ define(function(require) {
             })
             .style("cursor", "default")
             .style("font-weight", function(group){
-              if(selectedRibbon &&
-                (
-                  (selectedRibbon.sourceIndex === group.index) ||
-                  (selectedRibbon.targetIndex === group.index)
-                )
-              ){
-                return "bold";
-              } else {
-                return "normal";
-              }
+              return selected.get(this) ? "bold" : "normal";
             })
             .call(chordGroupHover);
 

--- a/public/chordDiagram.js
+++ b/public/chordDiagram.js
@@ -15,6 +15,7 @@ define(function(require) {
         arcThickness = 20,
         padAngle = 0.07,
         labelPadding = 10,
+        transitionDuration = 500,
 
         // Opacity values common to ribbons and arcs
         // depending on whether or not they are selected.
@@ -187,10 +188,19 @@ define(function(require) {
             .style("fill", function(group) {
               return color(matrix.names[group.index]);
             })
+            .call(chordGroupHover)
+            .call(setArcOpacity);
+
+        function setArcOpacity(selection){
+          selection.transition().duration(transitionDuration)
             .style("opacity", function(group){
-              return selected.get(this.parentNode) ? defaultOpacity : fadedOpacity;
-            })
-            .call(chordGroupHover);
+              if(selectedRibbon){
+                return selected.get(this.parentNode) ? defaultOpacity : fadedOpacity;
+              } else {
+                return defaultOpacity;
+              }
+            });
+        }
 
 
         // Sets up hover interaction to highlight a chord group.
@@ -210,7 +220,7 @@ define(function(require) {
         // Sets the opacity values for all ribbons.
         function setRibbonOpacity(selection){
           selection
-            .transition().duration(500)
+            .transition().duration(transitionDuration)
             .style("opacity", function (d){
 
               // If there is a currently selected ribbon,

--- a/public/chordDiagram.js
+++ b/public/chordDiagram.js
@@ -35,10 +35,19 @@ define(function(require) {
         source = function (d){ return d[chordSourceColumn]; },
         destination = function (d){ return d[chordDestinationColumn]; };
 
-    // D3 Local objects for DOM-local storage of label angles and
-    // whether or not labels should be flipped upside-down.
-    var angle = d3.local(),
-        flip = d3.local();
+    // D3 Local objects for DOM-local storage.
+    var
+
+        // Stores label angles.
+        angle = d3.local(),
+
+        // Stores whether or not labels should be flipped upside-down.
+        flip = d3.local(),
+
+        // Stores whether or not this label is for a chord group
+        // that is either the source or destination of the
+        // selected ribbon.
+        selected = d3.local();
 
     // DOM Elements.
     var svg = d3.select(div).append("svg")

--- a/public/chordDiagram.js
+++ b/public/chordDiagram.js
@@ -166,11 +166,11 @@ define(function(require) {
           selection
             .on("mouseover", function (group){
               hoveredChordGroup = group;
-              setRibbonOpacity(ribbons);
+              my();
             })
             .on("mouseout", function (){
               hoveredChordGroup = null;
-              setRibbonOpacity(ribbons);
+              my();
             });
         }
 

--- a/public/chordDiagram.js
+++ b/public/chordDiagram.js
@@ -129,30 +129,30 @@ define(function(require) {
         // Add labels
         chordGroups
           .select("text")
-            .each(function(d) {
-              angle.set(this, (d.startAngle + d.endAngle) / 2);
+            .each(function(group) {
+              angle.set(this, (group.startAngle + group.endAngle) / 2);
               flip.set(this, angle.get(this) > Math.PI);
             })
-            .attr("transform", function(d) {
+            .attr("transform", function() {
               return [
                 "rotate(" + (angle.get(this) / Math.PI * 180 - 90) + ")",
                 "translate(" + (outerRadius + labelPadding) + ")",
                 flip.get(this) ? "rotate(180)" : ""
               ].join("");
             })
-            .attr("text-anchor", function(d) {
+            .attr("text-anchor", function() {
               return flip.get(this) ? "end" : "start";
             })
             .attr("alignment-baseline", "central")
-            .text(function(d) {
-              return matrix.names[d.index];
+            .text(function(group) {
+              return matrix.names[group.index];
             })
             .style("cursor", "default")
-            .style("font-weight", function(d){
+            .style("font-weight", function(group){
               if(selectedRibbon &&
                 (
-                  (selectedRibbon.sourceIndex === d.index) ||
-                  (selectedRibbon.targetIndex === d.index)
+                  (selectedRibbon.sourceIndex === group.index) ||
+                  (selectedRibbon.targetIndex === group.index)
                 )
               ){
                 return "bold";

--- a/public/chordDiagram.js
+++ b/public/chordDiagram.js
@@ -126,13 +126,17 @@ define(function(require) {
         chordGroups.exit().remove();
         chordGroups = chordGroups.merge(chordGroupsEnter);
 
-        // Add labels
+        // Compute locals.
         chordGroups
           .select("text")
             .each(function(group) {
               angle.set(this, (group.startAngle + group.endAngle) / 2);
               flip.set(this, angle.get(this) > Math.PI);
             })
+
+        // Add labels
+        chordGroups
+          .select("text")
             .attr("transform", function() {
               return [
                 "rotate(" + (angle.get(this) / Math.PI * 180 - 90) + ")",

--- a/public/chordDiagram.js
+++ b/public/chordDiagram.js
@@ -179,7 +179,8 @@ define(function(require) {
             .style("font-weight", function(group){
               return selected.get(this.parentNode) ? "bold" : "normal";
             })
-            .call(chordGroupHover);
+            .call(chordGroupHover)
+            .call(setChordGroupOpacity);
 
         // Render the chord group arcs.
         chordGroups
@@ -189,9 +190,9 @@ define(function(require) {
               return color(matrix.names[group.index]);
             })
             .call(chordGroupHover)
-            .call(setArcOpacity);
+            .call(setChordGroupOpacity);
 
-        function setArcOpacity(selection){
+        function setChordGroupOpacity(selection){
           selection.transition().duration(transitionDuration)
             .style("opacity", function(group){
               if(selectedRibbon){


### PR DESCRIPTION
This PR makes the selected ribbon much more pronounced.

These changes will make usage of the tool more intuitive, by indicating clearly which mode the visualization is in - something selected, or nothing selected.
- [x] Change arc opacity based on selected ribbon
- [x] Change text opacity based on selected ribbon
- [x] Make text bold for chord group labels connected to the selected ribbon #57
